### PR TITLE
CLI args

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+save/
+**/__pycache__
+experiment-log-*.csv

--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-import getopt
+from argparse import ArgumentParser
 import sys
 
 from colorama import Fore
@@ -12,17 +12,21 @@ from models.seqgan.Seqgan import Seqgan
 from models.textGan_MMD.Textgan import TextganMmd
 
 
+supported_gans = {
+    'seqgan': Seqgan,
+    'gsgan': Gsgan,
+    'textgan': TextganMmd,
+    'leakgan': Leakgan,
+    'rankgan': Rankgan,
+    'maligan': Maligan,
+    'mle': Mle
+}
+supported_training = {'oracle', 'cfg', 'real'}
+
+
 def set_gan(gan_name):
-    gans = dict()
-    gans['seqgan'] = Seqgan
-    gans['gsgan'] = Gsgan
-    gans['textgan'] = TextganMmd
-    gans['leakgan'] = Leakgan
-    gans['rankgan'] = Rankgan
-    gans['maligan'] = Maligan
-    gans['mle'] = Mle
     try:
-        Gan = gans[gan_name.lower()]
+        Gan = supported_gans[gan_name.lower()]
         gan = Gan()
         gan.vocab_size = 5000
         gan.generate_num = 10000
@@ -30,7 +34,6 @@ def set_gan(gan_name):
     except KeyError:
         print(Fore.RED + 'Unsupported GAN type: ' + gan_name + Fore.RESET)
         sys.exit(-2)
-
 
 
 def set_training(gan, training_method):
@@ -50,36 +53,20 @@ def set_training(gan, training_method):
     return gan_func
 
 
-def parse_cmd(argv):
-    try:
-        opts, args = getopt.getopt(argv, "hg:t:d:")
-
-        opt_arg = dict(opts)
-        if '-h' in opt_arg.keys():
-            print('usage: python main.py -g <gan_type>')
-            print('       python main.py -g <gan_type> -t <train_type>')
-            print('       python main.py -g <gan_type> -t realdata -d <your_data_location>')
-            sys.exit(0)
-        if not '-g' in opt_arg.keys():
-            print('unspecified GAN type, use MLE training only...')
-            gan = set_gan('mle')
-        else:
-            gan = set_gan(opt_arg['-g'])
-        if not '-t' in opt_arg.keys():
-            gan.train_oracle()
-        else:
-            gan_func = set_training(gan, opt_arg['-t'])
-            if opt_arg['-t'] == 'real' and '-d' in opt_arg.keys():
-                gan_func(opt_arg['-d'])
-            else:
-                gan_func()
-    except getopt.GetoptError:
-        print('invalid arguments!')
-        print('`python main.py -h`  for help')
-        sys.exit(-1)
-    pass
-
+def parse_cmd():
+    parser = ArgumentParser()
+    parser.add_argument('-g', '--gan-type', help='The type of GAN to use',
+                        choices=set(supported_gans.keys()), default='mle')
+    parser.add_argument('-t', '--train-type', help='Type of training to use',
+                        choices=supported_training, default='oracle')
+    parser.add_argument('-d', '--data', default='data/image_coco.txt')
+    return parser.parse_known_args()
 
 if __name__ == '__main__':
-    gan = None
-    parse_cmd(sys.argv[1:])
+    args, unused_args = parse_cmd()
+    gan = set_gan(args.gan_type)
+    train_f = set_training(gan, args.train_type)
+    if args.train_type == 'real':
+        train_f(args.data)
+    else:
+        train_f()

--- a/main.py
+++ b/main.py
@@ -64,6 +64,9 @@ def parse_cmd():
 
 if __name__ == '__main__':
     parse_cmd()
+    tf.app.flags.DEFINE_string('oracle_file', 'save/oracle.txt', '')
+    tf.app.flags.DEFINE_string('generator_file', 'save/generator.txt', '')
+    tf.app.flags.DEFINE_string('test_file', 'save/test_file.txt', '')
     flags = tf.app.flags.FLAGS
     gan = set_gan(flags.gan_type)
     train_f = set_training(gan, flags.train_type)

--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
-from argparse import ArgumentParser
 import sys
 
 from colorama import Fore
+import tensorflow as tf
 
 from models.gsgan.Gsgan import Gsgan
 from models.leakgan.Leakgan import Leakgan
@@ -54,19 +54,20 @@ def set_training(gan, training_method):
 
 
 def parse_cmd():
-    parser = ArgumentParser()
-    parser.add_argument('-g', '--gan-type', help='The type of GAN to use',
-                        choices=set(supported_gans.keys()), default='mle')
-    parser.add_argument('-t', '--train-type', help='Type of training to use',
-                        choices=supported_training, default='oracle')
-    parser.add_argument('-d', '--data', default='data/image_coco.txt')
-    return parser.parse_known_args()
+    flags = tf.app.flags
+    flags.DEFINE_enum('gan_type', 'mle', list(supported_gans.keys()),
+                      'Type of GAN to use')
+    flags.DEFINE_enum('train_type', 'oracle', supported_training,
+                      'Type of training to use')
+    flags.DEFINE_string('data', 'data/image_coco.txt', '')
+    return
 
 if __name__ == '__main__':
-    args, unused_args = parse_cmd()
-    gan = set_gan(args.gan_type)
-    train_f = set_training(gan, args.train_type)
-    if args.train_type == 'real':
-        train_f(args.data)
+    parse_cmd()
+    flags = tf.app.flags.FLAGS
+    gan = set_gan(flags.gan_type)
+    train_f = set_training(gan, flags.train_type)
+    if flags.train_type == 'real':
+        train_f(flags.data)
     else:
         train_f()

--- a/models/Gan.py
+++ b/models/Gan.py
@@ -1,4 +1,5 @@
 from abc import abstractmethod
+from tensorflow.app import flags
 
 from utils.utils import init_sess
 
@@ -18,6 +19,15 @@ class Gan:
         self.adversarial_epoch_num = 100
         self.log = None
         self.reward = None
+
+        flags.DEFINE_string('oracle_file', 'save/oracle.txt', '')
+        flags.DEFINE_string('generator_file', 'save/generator.txt', '')
+        flags.DEFINE_string('test_file', 'save/test_file.txt', '')
+        FLAGS = flags.FLAGS
+        self.oracle_file = FLAGS.oracle_file
+        self.generator_file = FLAGS.generator_file
+        self.test_file = FLAGS.test_file
+
 
     def set_oracle(self, oracle):
         self.oracle = oracle

--- a/models/Gan.py
+++ b/models/Gan.py
@@ -20,9 +20,6 @@ class Gan:
         self.log = None
         self.reward = None
 
-        flags.DEFINE_string('oracle_file', 'save/oracle.txt', '')
-        flags.DEFINE_string('generator_file', 'save/generator.txt', '')
-        flags.DEFINE_string('test_file', 'save/test_file.txt', '')
         FLAGS = flags.FLAGS
         self.oracle_file = FLAGS.oracle_file
         self.generator_file = FLAGS.generator_file

--- a/models/gsgan/Gsgan.py
+++ b/models/gsgan/Gsgan.py
@@ -31,10 +31,6 @@ class Gsgan(Gan):
         self.generate_num = 128
         self.start_token = 0
 
-        self.oracle_file = 'save/oracle.txt'
-        self.generator_file = 'save/generator.txt'
-        self.test_file = 'save/test_file.txt'
-
     def init_oracle_trainng(self, oracle=None):
         if oracle is None:
             oracle = OracleLstm(num_vocabulary=self.vocab_size, batch_size=self.batch_size, emb_dim=self.emb_dim,

--- a/models/leakgan/Leakgan.py
+++ b/models/leakgan/Leakgan.py
@@ -72,10 +72,6 @@ class Leakgan(Gan):
         self.dis_embedding_dim = 64
         self.goal_size = 16
 
-        self.oracle_file = 'save/oracle.txt'
-        self.generator_file = 'save/generator.txt'
-        self.test_file = 'save/test_file.txt'
-
     def init_oracle_trainng(self, oracle=None):
         goal_out_size = sum(self.num_filters)
 

--- a/models/maligan_basic/Maligan.py
+++ b/models/maligan_basic/Maligan.py
@@ -28,10 +28,6 @@ class Maligan(Gan):
         self.generate_num = 128
         self.start_token = 0
 
-        self.oracle_file = 'save/oracle.txt'
-        self.generator_file = 'save/generator.txt'
-        self.test_file = 'save/test_file.txt'
-
     def init_oracle_trainng(self, oracle=None):
         if oracle is None:
             oracle = OracleLstm(num_vocabulary=self.vocab_size, batch_size=self.batch_size, emb_dim=self.emb_dim,

--- a/models/mle/Mle.py
+++ b/models/mle/Mle.py
@@ -26,10 +26,6 @@ class Mle(Gan):
         self.generate_num = 128
         self.start_token = 0
 
-        self.oracle_file = 'save/oracle.txt'
-        self.generator_file = 'save/generator.txt'
-        self.test_file = 'save/test_file.txt'
-
     def init_oracle_trainng(self, oracle=None):
         if oracle is None:
             oracle = OracleLstm(num_vocabulary=self.vocab_size, batch_size=self.batch_size, emb_dim=self.emb_dim,

--- a/models/pg_bleu/Pgbleu.py
+++ b/models/pg_bleu/Pgbleu.py
@@ -27,9 +27,6 @@ class Pgbleu(Gan):
         self.generate_num = 128
         self.start_token = 0
 
-        self.oracle_file = 'save/oracle.txt'
-        self.generator_file = 'save/generator.txt'
-
     def init_oracle_trainng(self, oracle=None):
         if oracle is None:
             oracle = OracleLstm(num_vocabulary=self.vocab_size, batch_size=self.batch_size, emb_dim=self.emb_dim,

--- a/models/rankgan/Rankgan.py
+++ b/models/rankgan/Rankgan.py
@@ -28,10 +28,6 @@ class Rankgan(Gan):
         self.generate_num = 128
         self.start_token = 0
 
-        self.oracle_file = 'save/oracle.txt'
-        self.generator_file = 'save/generator.txt'
-        self.test_file = 'save/test_file.txt'
-
     def init_oracle_trainng(self, oracle=None):
         if oracle is None:
             oracle = OracleLstm(num_vocabulary=self.vocab_size, batch_size=self.batch_size, emb_dim=self.emb_dim,

--- a/models/seqgan/Seqgan.py
+++ b/models/seqgan/Seqgan.py
@@ -31,10 +31,6 @@ class Seqgan(Gan):
         self.generate_num = 128
         self.start_token = 0
 
-        self.oracle_file = 'save/oracle.txt'
-        self.generator_file = 'save/generator.txt'
-        self.test_file = 'save/test_file.txt'
-
     def init_metric(self):
         nll = Nll(data_loader=self.oracle_data_loader, rnn=self.oracle, sess=self.sess)
         self.add_metric(nll)

--- a/models/textGan_MMD/Textgan.py
+++ b/models/textGan_MMD/Textgan.py
@@ -50,10 +50,6 @@ class TextganMmd(Gan):
         self.generate_num = 128
         self.start_token = 0
 
-        self.oracle_file = 'save/oracle.txt'
-        self.generator_file = 'save/generator.txt'
-        self.test_file = 'save/test_file.txt'
-
     def init_oracle_trainng(self, oracle=None):
         if oracle is None:
             oracle = OracleLstm(num_vocabulary=self.vocab_size, batch_size=self.batch_size, emb_dim=self.emb_dim,


### PR DESCRIPTION
# Motivation

Out of the box, LeakGAN does not work when specified through `main.py`. Instead, an error occurs that TensorFlow flags doesn't know how to parse argument `'g'`. This is due to the fact that `main.py` parses arguments with `getopt`, but the LeakGAN constructor uses `tf.app.flags`.

# Changes

To get LeakGAN to work properly, I modified `main.py` to also utilize `tf.app.flags`. Since these flags are intended to be global and distributed, it's perfectly legal to have flags specified in different parts of the system (i.e. LeakGAN specific args only in the LeakGAN constructor). The overall functionality is identical, with the exception that `main.py` args need to use their longform version (e.g. `--gan_type` instead of just `-g`).

Additionally, I factored out the definitions of the `test_file`, `oracle_file`, and `generator_file` to the `Gan` class (since they were used by every GAN type), and made them able to be specified by CLI args as well.